### PR TITLE
make the whole list item clickable in nav drawer

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,7 +41,7 @@
 
         <ExpandableListView
             android:id="@+id/navigationmenu"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginTop="150dp"
             android:background="@android:color/white" />


### PR DESCRIPTION
By default, width of the list element in nav drawer is set to `wrap_content`, this PR changes it to `match_parent` so that it can be clicked anywhere to go to the respective algorithm.